### PR TITLE
send stats in get packages and get groups route

### DIFF
--- a/app/Controllers/GroupController.js
+++ b/app/Controllers/GroupController.js
@@ -22,18 +22,25 @@ const sendGroups = catchAsync(async (req, res) => {
   // get language package id from params
   const { languagePackageId } = req.params;
 
-  // create language Package
+  // decide if we have to fetch stats
+  const includeStats = (req.query.stats || false) === 'true';
+
+  // get groups
   const groups = await getGroups(userId, languagePackageId);
 
   const formatted = await Promise.all(
     groups.map(async (group) => ({
       ...group.toJSON(),
 
-      stats: await getStats({
-        groupId: group.id,
-        languagePackageId,
-        userId,
-      }),
+      ...(includeStats
+        ? {
+            stats: await getStats({
+              groupId: group.id,
+              languagePackageId,
+              userId,
+            }),
+          }
+        : {}),
     }))
   );
 

--- a/app/Controllers/GroupController.js
+++ b/app/Controllers/GroupController.js
@@ -1,4 +1,5 @@
 const { createGroup, getGroups, destroyGroup, updateGroup } = require('../Services/GroupServiceProvider.js');
+const { getStats } = require('../Services/QueryServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
 
 const addGroup = catchAsync(async (req, res) => {
@@ -24,7 +25,19 @@ const sendGroups = catchAsync(async (req, res) => {
   // create language Package
   const groups = await getGroups(userId, languagePackageId);
 
-  res.send(groups);
+  const formatted = await Promise.all(
+    groups.map(async (group) => ({
+      ...group.toJSON(),
+
+      stats: await getStats({
+        groupId: group.id,
+        languagePackageId,
+        userId,
+      }),
+    }))
+  );
+
+  res.send(formatted);
 });
 
 const deleteGroup = catchAsync(async (req, res) => {

--- a/app/Controllers/GroupController.js
+++ b/app/Controllers/GroupController.js
@@ -1,5 +1,5 @@
 const { createGroup, getGroups, destroyGroup, updateGroup } = require('../Services/GroupServiceProvider.js');
-const { getStats } = require('../Services/QueryServiceProvider.js');
+const { getStats } = require('../Services/StatsServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
 
 const addGroup = catchAsync(async (req, res) => {

--- a/app/Controllers/LanguagePackageController.js
+++ b/app/Controllers/LanguagePackageController.js
@@ -26,20 +26,24 @@ const addLanguagePackage = catchAsync(async (req, res) => {
 const sendLanguagePackages = catchAsync(async (req, res) => {
   // get userId from request
   const userId = req.user.id;
-  const groups = req.query.groups || false;
-  const groupsActive = groups === 'true';
+  const includeGroups = (req.query.groups || false) === 'true';
+  const includeStats = (req.query.stats || false) === 'true';
 
   // get language Package
-  const languagePackages = await getLanguagePackages(userId, groupsActive);
+  const languagePackages = await getLanguagePackages(userId, includeGroups);
 
   const formatted = await Promise.all(
     languagePackages.map(async (languagePackage) => ({
       ...languagePackage.toJSON(),
 
-      stats: await getStats({
-        languagePackageId: languagePackage.id,
-        userId,
-      }),
+      ...(includeStats
+        ? {
+            stats: await getStats({
+              languagePackageId: languagePackage.id,
+              userId,
+            }),
+          }
+        : {}),
     }))
   );
 

--- a/app/Controllers/LanguagePackageController.js
+++ b/app/Controllers/LanguagePackageController.js
@@ -6,10 +6,7 @@ const {
 } = require('../Services/LanguagePackageServiceProvider.js');
 const { createDrawers } = require('../Services/DrawerServiceProvider.js');
 const { drawers } = require('../utils/constants.js');
-const {
-  getNumberOfUnresolvedVocabulary,
-  getNumberOfUnactivatedVocabulary,
-} = require('../Services/QueryServiceProvider.js');
+const { getStats } = require('../Services/QueryServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
 
 const addLanguagePackage = catchAsync(async (req, res) => {
@@ -35,15 +32,14 @@ const sendLanguagePackages = catchAsync(async (req, res) => {
   // get language Package
   const languagePackages = await getLanguagePackages(userId, groupsActive);
 
-  // if groups is true, return groups to every language package
   const formatted = await Promise.all(
     languagePackages.map(async (languagePackage) => ({
-      unresolvedVocabularies: await getNumberOfUnresolvedVocabulary(languagePackage.id, userId),
-
-      // add number of unactivated vocabularies
-      unactivatedVocabularies: await getNumberOfUnactivatedVocabulary(languagePackage.id, userId),
-
       ...languagePackage.toJSON(),
+
+      stats: await getStats({
+        languagePackageId: languagePackage.id,
+        userId,
+      }),
     }))
   );
 

--- a/app/Controllers/LanguagePackageController.js
+++ b/app/Controllers/LanguagePackageController.js
@@ -6,7 +6,7 @@ const {
 } = require('../Services/LanguagePackageServiceProvider.js');
 const { createDrawers } = require('../Services/DrawerServiceProvider.js');
 const { drawers } = require('../utils/constants.js');
-const { getStats } = require('../Services/QueryServiceProvider.js');
+const { getStats } = require('../Services/StatsServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
 
 const addLanguagePackage = catchAsync(async (req, res) => {

--- a/app/Controllers/StatsController.js
+++ b/app/Controllers/StatsController.js
@@ -9,26 +9,24 @@ const { promiseAllValues } = require('../utils/index.js');
 const sendAccountStats = catchAsync(async (req, res) => {
   const userId = req.user.id;
 
-  const stats = {
+  const stats = await promiseAllValues({
     // get number of language packages
-    languagePackages: getNumberOfLanguagePackages(userId),
+    languagePackages: getNumberOfLanguagePackages({ userId }),
 
     // get number of active groups
-    activeGroups: getNumberOfGroups(userId, true),
+    activeGroups: getNumberOfGroups({ userId, active: true }),
 
     // get number of inactive groups
-    inactiveGroups: getNumberOfGroups(userId, false),
+    inactiveGroups: getNumberOfGroups({ userId, active: false }),
 
     // get number of active vocabulary
-    activeVocabulary: getNumberOfVocabulary(userId, true),
+    activeVocabulary: getNumberOfVocabulary({ userId, active: true }),
 
     // get number of inactive vocabulary
-    inactiveVocabulary: getNumberOfVocabulary(userId, false),
-  };
+    inactiveVocabulary: getNumberOfVocabulary({ userId, active: false }),
+  });
 
-  const resolvedStats = await promiseAllValues(stats);
-
-  res.send(resolvedStats);
+  res.send(stats);
 });
 
 module.exports = {

--- a/app/Controllers/StatsController.js
+++ b/app/Controllers/StatsController.js
@@ -1,30 +1,10 @@
-const {
-  getNumberOfLanguagePackages,
-  getNumberOfGroups,
-  getNumberOfVocabulary,
-} = require('../Services/StatsServiceProvider.js');
+const { getUserStats } = require('../Services/StatsServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
-const { promiseAllValues } = require('../utils/index.js');
 
 const sendAccountStats = catchAsync(async (req, res) => {
   const userId = req.user.id;
 
-  const stats = await promiseAllValues({
-    // get number of language packages
-    languagePackages: getNumberOfLanguagePackages({ userId }),
-
-    // get number of active groups
-    activeGroups: getNumberOfGroups({ userId, active: true }),
-
-    // get number of inactive groups
-    inactiveGroups: getNumberOfGroups({ userId, active: false }),
-
-    // get number of active vocabulary
-    activeVocabulary: getNumberOfVocabulary({ userId, active: true }),
-
-    // get number of inactive vocabulary
-    inactiveVocabulary: getNumberOfVocabulary({ userId, active: false }),
-  });
+  const stats = await getUserStats({ userId });
 
   res.send(stats);
 });

--- a/app/Services/LanguagePackageServiceProvider.js
+++ b/app/Services/LanguagePackageServiceProvider.js
@@ -24,6 +24,7 @@ async function createLanguagePackage(
 async function getLanguagePackages(userId, groups) {
   // Get user with email from database
   const languagePackages = await LanguagePackage.findAll({
+    // if groups is true, return groups to every language package
     include: groups ? [{ model: Group, attributes: ['id', 'name', 'active'] }] : [],
     attributes: ['id', 'name', 'foreignWordLanguage', 'translatedWordLanguage', 'vocabsPerDay', 'rightWords'],
     where: {

--- a/app/Services/StatsServiceProvider.js
+++ b/app/Services/StatsServiceProvider.js
@@ -1,6 +1,10 @@
-const { LanguagePackage, Group, VocabularyCard } = require('../../database');
+const { Op } = require('sequelize');
+const { LanguagePackage, Group, VocabularyCard, Drawer } = require('../../database');
+const { shiftDate, promiseAllValues } = require('../utils/index.js');
+const ApiError = require('../utils/ApiError');
+const httpStatus = require('http-status');
 
-async function getNumberOfLanguagePackages(userId) {
+async function getNumberOfLanguagePackages({ userId }) {
   const number = await LanguagePackage.count({
     where: {
       userId,
@@ -9,28 +13,146 @@ async function getNumberOfLanguagePackages(userId) {
   return number;
 }
 
-async function getNumberOfGroups(userId, active) {
+async function getNumberOfGroups({ userId, active }) {
   const number = await Group.count({
     where: {
       userId,
-      active: !!active,
+      active,
     },
   });
   return number;
 }
 
-async function getNumberOfVocabulary(userId, active) {
+async function getNumberOfVocabulary({ active = null, languagePackageId, groupId, userId }) {
   const number = await VocabularyCard.count({
+    include: [
+      {
+        model: Group,
+        attributes: ['active'],
+      },
+    ],
     where: {
       userId,
-      active: !!active,
+
+      ...(() => {
+        // only add active filter if active is defined
+        if (active !== null) {
+          // filter active vocabs
+          if (active) {
+            return {
+              active: true,
+              '$Group.active$': true,
+            };
+          }
+
+          // filter inactive vocabs
+          return {
+            [Op.or]: [{ active: false }, { '$Group.active$': false }],
+          };
+        }
+
+        // no active filter
+        return {};
+      })(),
+
+      ...(groupId ? { groupId } : {}),
+      ...(languagePackageId ? { languagePackageId } : {}),
     },
   });
   return number;
+}
+
+// return the number of unresolved vocabulary
+async function getNumberOfUnresolvedVocabulary({ languagePackageId, groupId, userId }) {
+  // Get drawers belonging to languagePackage
+  const drawers = await Drawer.findAll({
+    attributes: ['id', 'stage', 'queryInterval'],
+    where: {
+      userId,
+      languagePackageId,
+      stage: {
+        [Op.ne]: 0,
+      },
+    },
+  });
+
+  if (drawers.length === 0) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'no drawers found, because the language package does not exist');
+  }
+
+  let number = 0;
+
+  await Promise.all(
+    drawers.map(async (drawer) => {
+      // subtract query interval from actual date
+      const queryDate = shiftDate(new Date(), -drawer.queryInterval);
+
+      // compare query date with with last query
+      // if queryDate is less than lastQuery: still time
+      // if queryDate more than lastQuery: waiting time is over
+
+      const result = await VocabularyCard.count({
+        include: [
+          {
+            model: Group,
+            attributes: ['active'],
+          },
+        ],
+        where: {
+          drawerId: drawer.id,
+          ...(groupId ? { groupId } : {}),
+          lastQuery: { [Op.lt]: queryDate },
+          '$Group.active$': true,
+          active: true,
+        },
+      });
+      number += Number(result);
+    })
+  );
+
+  return number;
+}
+
+// return the number of unactivated vocabulary
+async function getNumberOfUnactivatedVocabulary({ languagePackageId, groupId, userId }) {
+  // Get number of vocabularies belonging to languagePackage
+  const number = await VocabularyCard.count({
+    include: [
+      {
+        model: Drawer,
+        attributes: ['stage'],
+        required: true,
+      },
+    ],
+    where: {
+      languagePackageId,
+      ...(groupId ? { groupId } : {}),
+      userId,
+      '$Drawer.stage$': 0,
+      active: true,
+    },
+  });
+
+  return number;
+}
+
+async function getStats({ languagePackageId, groupId, userId }) {
+  const stats = await promiseAllValues({
+    allVocabularies: getNumberOfVocabulary({ languagePackageId, groupId, userId }),
+    activeVocabularies: getNumberOfVocabulary({ languagePackageId, groupId, userId, active: true }),
+    inactiveVocabularies: getNumberOfVocabulary({ languagePackageId, groupId, userId, active: false }),
+    unresolvedVocabularies: getNumberOfUnresolvedVocabulary({ languagePackageId, groupId, userId }),
+    unactivatedVocabularies: getNumberOfUnactivatedVocabulary({ languagePackageId, groupId, userId }),
+  });
+
+  return stats;
 }
 
 module.exports = {
   getNumberOfLanguagePackages,
   getNumberOfGroups,
   getNumberOfVocabulary,
+  getNumberOfUnresolvedVocabulary,
+  getNumberOfUnactivatedVocabulary,
+  getStats,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  | Env Vars Change | 
| :---: | :---: | :---: |
| :white_check_mark: Ready | Feature | No |

## Description

<!--- Describe your changes in detail -->

- refactored stats function
- send vocab count in stats
- count voab in inactive group as inactive

### **BREAKING CHANGE PROFILE SCREEN WON'T WORK ANYMORE**

### API Output

<details>
<summary>

`GET /user/stats`

</summary>
<br>

```json
{
    "languagePackages": {
        "all": 4
    },
    "groups": {
        "all": 5,
        "active": 3,
        "inactive": 5
    },
    "vocabularies": {
        "all": 1007,
        "active": 1003,
        "inactive": 4
    }
}
```

</details>


<details>
<summary>

`GET api/languagePackage?groups=true&stats=true`

</summary>
<br>

```json
[
    {
        "id": "9160cdac-34b2-4edb-9aff-da82c57902bc",
        "name": "Englisch - Deutsch",
        "foreignWordLanguage": "Englisch",
        "translatedWordLanguage": "Deutsch",
        "vocabsPerDay": 50,
        "rightWords": 1,
        "Groups": [
            {
                "id": "745ae17d-a2bf-47db-bb26-cb691d45e1de",
                "name": "Unit 2",
                "active": true
            },
            {
                "id": "c49fb2c4-8815-4cd8-994a-3f8acf464bb8",
                "name": "Unit 1",
                "active": true
            }
        ],
        "stats": {
            "vocabularies": {
                "all": 1006,
                "active": 1003,
                "inactive": 3,
                "unresolved": 2,
                "unactivated": 1001
            }
        }
    }
]
```

</details>


<details>
<summary>

`GET /api/languagePackage/:languagePackageId/group?stats=true`

</summary>
<br>

```json
[
    {
        "id": "c49fb2c4-8815-4cd8-994a-3f8acf464bb8",
        "name": "Unit 1",
        "active": true,
        "stats": {
            "vocabularies": {
                "all": 1001,
                "active": 1000,
                "inactive": 1,
                "unresolved": 1,
                "unactivated": 999
            }
        }
    },
    {
        "id": "745ae17d-a2bf-47db-bb26-cb691d45e1de",
        "name": "Unit 2",
        "active": true,
        "stats": {
            "vocabularies": {
                "all": 5,
                "active": 3,
                "inactive": 2,
                "unresolved": 1,
                "unactivated": 2
            }
        }
    }
]
```

</details>

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / GIFs (if appropriate):
<!--- Bonus points for GIFS --->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking change which cleans up / improves existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
