### PR TITLE
fix: not set last query in correct staged vocab

### DIFF
--- a/app/Services/QueryServiceProvider.js
+++ b/app/Services/QueryServiceProvider.js
@@ -229,12 +229,17 @@ async function handleCorrectQuery(userId, vocabularyCardId) {
   }
 
   // update drawerId for vocabulary card
-  const lastQuery = new Date();
-  const lastQueryCorrect = new Date();
-  const drawerId = drawer.id;
-
   await vocabularyCard.update(
-    { lastQuery, lastQueryCorrect, drawerId },
+    {
+      // only count as correct if it wasn't in staged drawer
+      ...(vocabularyCard.Drawer.stage > 0
+        ? {
+            lastQuery: new Date(),
+            lastQueryCorrect: new Date(),
+          }
+        : {}),
+      drawerId: drawer.id,
+    },
     {
       fields: ['lastQuery', 'lastQueryCorrect', 'drawerId'],
     }
@@ -278,16 +283,21 @@ async function handleWrongQuery(userId, vocabularyCardId) {
     where: {
       userId,
       languagePackageId: vocabularyCard.languagePackageId,
-      stage: 1,
+      stage: vocabularyCard.Drawer.stage > 0 ? 1 : 0,
     },
   });
 
   // update drawerId for vocabulary card
-  const lastQuery = new Date();
-  const drawerId = drawer.id;
-
   await vocabularyCard.update(
-    { lastQuery, drawerId },
+    {
+      // only count as correct if it wasn't in staged drawer
+      ...(vocabularyCard.Drawer.stage > 0
+        ? {
+            lastQuery: new Date(),
+          }
+        : {}),
+      drawerId: drawer.id,
+    },
     {
       fields: ['lastQuery', 'drawerId'],
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| :white_check_mark: Ready | Bug | No |

## Description

- don't update `lastQuery` and `lastQueryCorrect` if vocab is in stage 0
- don't move vocab in first drawer, if it was staged (drawer 0)

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
