### PR TITLE
fix: 404 in user stats route if no packages found

### DIFF
--- a/app/Services/StatsServiceProvider.js
+++ b/app/Services/StatsServiceProvider.js
@@ -79,7 +79,7 @@ async function getNumberOfUnresolvedVocabulary({ languagePackageId, groupId, use
     },
   });
 
-  if (drawers.length === 0) {
+  if (languagePackageId && drawers.length === 0) {
     throw new ApiError(httpStatus.NOT_FOUND, 'no drawers found, because the language package does not exist');
   }
 
@@ -152,7 +152,7 @@ async function getNumberOfLearnedTodayVocabulary({ languagePackageId = null, use
     },
   });
 
-  if (!languagePackage) {
+  if (languagePackageId && !languagePackage) {
     throw new ApiError(httpStatus.NOT_FOUND, 'languagePackage not found');
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| :white_check_mark: Ready | Bug | No |

## Description

fix fetching user stats returns error when no package has been created, as route is trying to fetch non existing drawers

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
