### PR TITLE
Import/Export functions

### DIFF
--- a/app/Controllers/ExportController.js
+++ b/app/Controllers/ExportController.js
@@ -1,0 +1,31 @@
+const { getAllGroupVocabulary, getAllLanguagePackageVocabulary } = require('../Services/ExportServiceProvider.js');
+const catchAsync = require('../utils/catchAsync');
+
+const exportGroup = catchAsync(async (req, res) => {
+  // get userId from request
+  const userId = req.user.id;
+
+  // get language package id from params
+  const { groupId } = req.params;
+
+  const group = await getAllGroupVocabulary(userId, groupId);
+
+  res.send(group);
+});
+
+const exportLanguagePackage = catchAsync(async (req, res) => {
+  // get userId from request
+  const userId = req.user.id;
+
+  // get language package id from params
+  const { languagePackageId } = req.params;
+
+  const languagePackage = await getAllLanguagePackageVocabulary(userId, languagePackageId);
+
+  res.send(languagePackage);
+});
+
+module.exports = {
+  exportGroup,
+  exportLanguagePackage,
+};

--- a/app/Controllers/ExportController.js
+++ b/app/Controllers/ExportController.js
@@ -19,8 +19,9 @@ const exportLanguagePackage = catchAsync(async (req, res) => {
 
   // get language package id from params
   const { languagePackageId } = req.params;
+  const queryStatus = (req.query.queryStatus || 'false') === 'true';
 
-  const languagePackage = await getAllLanguagePackageVocabulary(userId, languagePackageId);
+  const languagePackage = await getAllLanguagePackageVocabulary({ userId, languagePackageId, queryStatus });
 
   res.send(languagePackage);
 });

--- a/app/Controllers/ExportController.js
+++ b/app/Controllers/ExportController.js
@@ -1,5 +1,6 @@
 const { getAllGroupVocabulary, getAllLanguagePackageVocabulary } = require('../Services/ExportServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
+const { getVersion } = require('../Services/InfoServiceProvider');
 
 const exportGroup = catchAsync(async (req, res) => {
   // get userId from request
@@ -9,8 +10,12 @@ const exportGroup = catchAsync(async (req, res) => {
   const { groupId } = req.params;
 
   const group = await getAllGroupVocabulary(userId, groupId);
-
-  res.send(group);
+  const formatted = {
+    version: getVersion(),
+    type: 'vocascan/group',
+    ...group.toJSON(),
+  };
+  res.send(formatted);
 });
 
 const exportLanguagePackage = catchAsync(async (req, res) => {
@@ -22,8 +27,13 @@ const exportLanguagePackage = catchAsync(async (req, res) => {
   const queryStatus = (req.query.queryStatus || 'false') === 'true';
 
   const languagePackage = await getAllLanguagePackageVocabulary({ userId, languagePackageId, queryStatus });
+  const formatted = {
+    version: getVersion(),
+    type: 'vocascan/package',
+    ...languagePackage.toJSON(),
+  };
 
-  res.send(languagePackage);
+  res.send(formatted);
 });
 
 module.exports = {

--- a/app/Controllers/ImportController.js
+++ b/app/Controllers/ImportController.js
@@ -1,32 +1,30 @@
 const { storeGroupVocabulary, storeLanguagePackageVocabulary } = require('../Services/ImportServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
 
-const importGroup = catchAsync(async(req, res) => {
-    // get userId from request
-    const userId = req.user.id;
+const importGroup = catchAsync(async (req, res) => {
+  // get userId from request
+  const userId = req.user.id;
 
-    const { active, activate, languagePackageId } = req.query;
+  const { active, activate, languagePackageId } = req.query;
 
-    await storeGroupVocabulary(req.body, userId, languagePackageId, active, activate);
+  await storeGroupVocabulary(req.body, userId, languagePackageId, active, activate);
 
-    res.send('stored');
+  res.status(204).end();
 });
 
-const importLanguagePackage = catchAsync(async(req, res) => {
-    // get userId from request
-    const userId = req.user.id;
+const importLanguagePackage = catchAsync(async (req, res) => {
+  // get userId from request
+  const userId = req.user.id;
 
-    // get group with vocabs from request body
-    const { active, activate } = req.query;
+  // get group with vocabs from request body
+  const { active, activate } = req.query;
 
-    await storeLanguagePackageVocabulary(req.body, userId, active, activate);
+  await storeLanguagePackageVocabulary(req.body, userId, active, activate);
 
-    // await storeLanguagePackageVocabulary(group);
-
-    res.send('stored');
+  res.status(204).end();
 });
 
 module.exports = {
-    importGroup,
-    importLanguagePackage,
+  importGroup,
+  importLanguagePackage,
 };

--- a/app/Controllers/ImportController.js
+++ b/app/Controllers/ImportController.js
@@ -5,7 +5,9 @@ const importGroup = catchAsync(async (req, res) => {
   // get userId from request
   const userId = req.user.id;
 
-  const { active, activate, languagePackageId } = req.query;
+  const active = (req.query.active || 'true') === 'true';
+  const activate = (req.query.activate || 'false') === 'true';
+  const { languagePackageId } = req.query;
 
   await storeGroupVocabulary(req.body, userId, languagePackageId, active, activate);
 
@@ -16,10 +18,11 @@ const importLanguagePackage = catchAsync(async (req, res) => {
   // get userId from request
   const userId = req.user.id;
 
-  // get group with vocabs from request body
-  const { active, activate } = req.query;
+  const active = (req.query.active || 'true') === 'true';
+  const activate = (req.query.activate || 'false') === 'true';
+  const queryStatus = (req.query.queryStatus || 'false') === 'true';
 
-  await storeLanguagePackageVocabulary(req.body, userId, active, activate);
+  await storeLanguagePackageVocabulary(req.body, userId, active, activate, queryStatus);
 
   res.status(204).end();
 });

--- a/app/Controllers/ImportController.js
+++ b/app/Controllers/ImportController.js
@@ -1,7 +1,9 @@
 const { storeGroupVocabulary, storeLanguagePackageVocabulary } = require('../Services/ImportServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
+const ApiError = require('../utils/ApiError.js');
+const httpStatus = require('http-status');
 
-const importGroup = catchAsync(async (req, res) => {
+const importVocabs = catchAsync(async (req, res) => {
   // get userId from request
   const userId = req.user.id;
 
@@ -9,25 +11,23 @@ const importGroup = catchAsync(async (req, res) => {
   const activate = (req.query.activate || 'false') === 'true';
   const { languagePackageId } = req.query;
 
-  await storeGroupVocabulary(req.body, userId, languagePackageId, active, activate);
+  const { type } = req.body;
+  // use different types of import to separate the functions
+  if (!type) {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'imported data has no Vocascan structure');
+  } else if (type === 'vocascan/package') {
+    const queryStatus = (req.query.queryStatus || 'false') === 'true';
 
-  res.status(204).end();
-});
-
-const importLanguagePackage = catchAsync(async (req, res) => {
-  // get userId from request
-  const userId = req.user.id;
-
-  const active = (req.query.active || 'true') === 'true';
-  const activate = (req.query.activate || 'false') === 'true';
-  const queryStatus = (req.query.queryStatus || 'false') === 'true';
-
-  await storeLanguagePackageVocabulary(req.body, userId, active, activate, queryStatus);
+    await storeLanguagePackageVocabulary(req.body, userId, active, activate, queryStatus);
+  } else if (type === 'vocascan/group') {
+    await storeGroupVocabulary(req.body, userId, languagePackageId, active, activate);
+  } else {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'imported data type not recognized');
+  }
 
   res.status(204).end();
 });
 
 module.exports = {
-  importGroup,
-  importLanguagePackage,
+  importVocabs,
 };

--- a/app/Controllers/ImportController.js
+++ b/app/Controllers/ImportController.js
@@ -1,33 +1,32 @@
 const { storeGroupVocabulary, storeLanguagePackageVocabulary } = require('../Services/ImportServiceProvider.js');
 const catchAsync = require('../utils/catchAsync');
 
-const importGroup = catchAsync(async (req, res) => {
-  // get userId from request
-  const userId = req.user.id;
+const importGroup = catchAsync(async(req, res) => {
+    // get userId from request
+    const userId = req.user.id;
 
-  // get group with vocabs from request body
-  const { group, languagePackageId, active, activate } = req.body;
+    const { active, activate, languagePackageId } = req.query;
 
-  await storeGroupVocabulary(group, userId, languagePackageId, active, activate);
+    await storeGroupVocabulary(req.body, userId, languagePackageId, active, activate);
 
-  res.send('stored');
+    res.send('stored');
 });
 
-const importLanguagePackage = catchAsync(async (req, res) => {
-  // get userId from request
-  const userId = req.user.id;
+const importLanguagePackage = catchAsync(async(req, res) => {
+    // get userId from request
+    const userId = req.user.id;
 
-  // get group with vocabs from request body
-  const { languagePackage, active, activate } = req.body;
+    // get group with vocabs from request body
+    const { active, activate } = req.query;
 
-  await storeLanguagePackageVocabulary(languagePackage, userId, active, activate);
+    await storeLanguagePackageVocabulary(req.body, userId, active, activate);
 
-  // await storeLanguagePackageVocabulary(group);
+    // await storeLanguagePackageVocabulary(group);
 
-  res.send('stored');
+    res.send('stored');
 });
 
 module.exports = {
-  importGroup,
-  importLanguagePackage,
+    importGroup,
+    importLanguagePackage,
 };

--- a/app/Controllers/ImportController.js
+++ b/app/Controllers/ImportController.js
@@ -1,0 +1,33 @@
+const { storeGroupVocabulary, storeLanguagePackageVocabulary } = require('../Services/ImportServiceProvider.js');
+const catchAsync = require('../utils/catchAsync');
+
+const importGroup = catchAsync(async (req, res) => {
+  // get userId from request
+  const userId = req.user.id;
+
+  // get group with vocabs from request body
+  const { group, languagePackageId, active, activate } = req.body;
+
+  await storeGroupVocabulary(group, userId, languagePackageId, active, activate);
+
+  res.send('stored');
+});
+
+const importLanguagePackage = catchAsync(async (req, res) => {
+  // get userId from request
+  const userId = req.user.id;
+
+  // get group with vocabs from request body
+  const { languagePackage, active, activate } = req.body;
+
+  await storeLanguagePackageVocabulary(languagePackage, userId, active, activate);
+
+  // await storeLanguagePackageVocabulary(group);
+
+  res.send('stored');
+});
+
+module.exports = {
+  importGroup,
+  importLanguagePackage,
+};

--- a/app/Controllers/ImportController.js
+++ b/app/Controllers/ImportController.js
@@ -9,7 +9,6 @@ const importVocabs = catchAsync(async (req, res) => {
 
   const active = (req.query.active || 'true') === 'true';
   const activate = (req.query.activate || 'false') === 'true';
-  const { languagePackageId } = req.query;
 
   const { type } = req.body;
   // use different types of import to separate the functions
@@ -17,9 +16,9 @@ const importVocabs = catchAsync(async (req, res) => {
     throw new ApiError(httpStatus.BAD_REQUEST, 'imported data has no Vocascan structure');
   } else if (type === 'vocascan/package') {
     const queryStatus = (req.query.queryStatus || 'false') === 'true';
-
     await storeLanguagePackageVocabulary(req.body, userId, active, activate, queryStatus);
   } else if (type === 'vocascan/group') {
+    const { languagePackageId } = req.query;
     await storeGroupVocabulary(req.body, userId, languagePackageId, active, activate);
   } else {
     throw new ApiError(httpStatus.BAD_REQUEST, 'imported data type not recognized');

--- a/app/Controllers/VocabularyController.js
+++ b/app/Controllers/VocabularyController.js
@@ -17,15 +17,15 @@ const addVocabularyCard = catchAsync(async (req, res) => {
   const activate = req.query.activate === 'true';
 
   // create vocabulary card
-  const vocabularyCard = await createVocabularyCard(
+  const vocabularyCard = await createVocabularyCard({
     languagePackageId,
     groupId,
     name,
     description,
     userId,
     active,
-    activate
-  );
+    activate,
+  });
 
   // parse vocabulary card id from response and create translations
   await createTranslations(translations, userId, languagePackageId, vocabularyCard.id);

--- a/app/Controllers/VocabularyController.js
+++ b/app/Controllers/VocabularyController.js
@@ -11,13 +11,21 @@ const addVocabularyCard = catchAsync(async (req, res) => {
   // get userId from request
   const userId = req.user.id;
   const { name, description, active, translations } = req.body;
-  const { languagePackageId } = req.params;
+  const { languagePackageId, groupId } = req.params;
 
   // check if user wants to train vocabulary card directly
   const activate = req.query.activate === 'true';
 
   // create vocabulary card
-  const vocabularyCard = await createVocabularyCard(req.params, name, description, userId, active, activate);
+  const vocabularyCard = await createVocabularyCard(
+    languagePackageId,
+    groupId,
+    name,
+    description,
+    userId,
+    active,
+    activate
+  );
 
   // parse vocabulary card id from response and create translations
   await createTranslations(translations, userId, languagePackageId, vocabularyCard.id);

--- a/app/Services/DrawerServiceProvider.js
+++ b/app/Services/DrawerServiceProvider.js
@@ -13,11 +13,14 @@ async function createDrawer(languagePackageId, stage, queryInterval, userId) {
 }
 
 async function createDrawers(drawers, languagePackageId, userId) {
+  const allDrawers = [];
   await Promise.all(
     drawers.map(async (drawer) => {
-      await createDrawer(languagePackageId, drawer.stage, drawer.queryInterval, userId);
+      allDrawers.push(await createDrawer(languagePackageId, drawer.stage, drawer.queryInterval, userId));
     })
   );
+
+  return allDrawers;
 }
 
 module.exports = {

--- a/app/Services/DrawerServiceProvider.js
+++ b/app/Services/DrawerServiceProvider.js
@@ -12,15 +12,18 @@ async function createDrawer(languagePackageId, stage, queryInterval, userId) {
   return drawer;
 }
 
-async function createDrawers(drawers, languagePackageId, userId) {
-  const allDrawers = [];
-  await Promise.all(
-    drawers.map(async (drawer) => {
-      allDrawers.push(await createDrawer(languagePackageId, drawer.stage, drawer.queryInterval, userId));
-    })
+async function createDrawers(drawers, languagePackageId, userId, transaction) {
+  const createdDrawers = await Drawer.bulkCreate(
+    drawers.map((drawer) => ({
+      userId,
+      languagePackageId,
+      stage: drawer.stage,
+      queryInterval: drawer.queryInterval,
+    })),
+    { transaction }
   );
 
-  return allDrawers;
+  return createdDrawers;
 }
 
 module.exports = {

--- a/app/Services/ExportServiceProvider.js
+++ b/app/Services/ExportServiceProvider.js
@@ -1,0 +1,64 @@
+const { VocabularyCard, Translation, Group, LanguagePackage } = require('../../database');
+const ApiError = require('../utils/ApiError.js');
+const httpStatus = require('http-status');
+
+// get every vocabulary of a group
+async function getAllGroupVocabulary(userId, groupId) {
+  const group = await Group.findOne({
+    attributes: ['name', 'description'],
+    include: [
+      {
+        model: VocabularyCard,
+        attributes: ['name', 'description'],
+        include: [
+          {
+            model: Translation,
+            attributes: ['name'],
+          },
+        ],
+      },
+    ],
+    where: {
+      id: groupId,
+      userId,
+    },
+  });
+  return group;
+}
+
+async function getAllLanguagePackageVocabulary(userId, languagePackageId) {
+  // Get user with email from database
+  const languagePackage = await LanguagePackage.findOne({
+    // if groups is true, return groups to every language package
+    include: [
+      {
+        model: Group,
+        attributes: ['name', 'description'],
+        include: [
+          {
+            model: VocabularyCard,
+            attributes: ['name', 'description'],
+            include: [
+              {
+                model: Translation,
+                attributes: ['name'],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    attributes: ['name', 'foreignWordLanguage', 'translatedWordLanguage', 'vocabsPerDay', 'rightWords'],
+    where: {
+      userId,
+      id: languagePackageId,
+    },
+  });
+
+  return languagePackage;
+}
+
+module.exports = {
+  getAllGroupVocabulary,
+  getAllLanguagePackageVocabulary,
+};

--- a/app/Services/ExportServiceProvider.js
+++ b/app/Services/ExportServiceProvider.js
@@ -1,4 +1,4 @@
-const { VocabularyCard, Translation, Group, LanguagePackage } = require('../../database');
+const { VocabularyCard, Translation, Group, LanguagePackage, Drawer } = require('../../database');
 
 // get every vocabulary of a group
 async function getAllGroupVocabulary(userId, groupId) {
@@ -24,28 +24,51 @@ async function getAllGroupVocabulary(userId, groupId) {
   return group;
 }
 
-async function getAllLanguagePackageVocabulary(userId, languagePackageId) {
+async function getAllLanguagePackageVocabulary({ userId, languagePackageId, queryStatus }) {
   // Get user with email from database
   const languagePackage = await LanguagePackage.findOne({
     // if groups is true, return groups to every language package
-    include: [
-      {
-        model: Group,
-        attributes: ['name', 'description'],
-        include: [
+    include: queryStatus
+      ? [
           {
-            model: VocabularyCard,
+            model: Group,
             attributes: ['name', 'description'],
             include: [
               {
-                model: Translation,
-                attributes: ['name'],
+                model: VocabularyCard,
+                attributes: queryStatus ? ['name', 'description', 'drawerId'] : ['name', 'description'],
+                include: [
+                  {
+                    model: Translation,
+                    attributes: ['name'],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            model: Drawer,
+            attributes: ['id', 'stage', 'queryInterval'],
+          },
+        ]
+      : [
+          {
+            model: Group,
+            attributes: ['name', 'description'],
+            include: [
+              {
+                model: VocabularyCard,
+                attributes: queryStatus ? ['name', 'description', 'drawerId'] : ['name', 'description'],
+                include: [
+                  {
+                    model: Translation,
+                    attributes: ['name'],
+                  },
+                ],
               },
             ],
           },
         ],
-      },
-    ],
     attributes: ['name', 'foreignWordLanguage', 'translatedWordLanguage', 'vocabsPerDay', 'rightWords'],
     where: {
       userId,

--- a/app/Services/ExportServiceProvider.js
+++ b/app/Services/ExportServiceProvider.js
@@ -1,6 +1,4 @@
 const { VocabularyCard, Translation, Group, LanguagePackage } = require('../../database');
-const ApiError = require('../utils/ApiError.js');
-const httpStatus = require('http-status');
 
 // get every vocabulary of a group
 async function getAllGroupVocabulary(userId, groupId) {

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -25,15 +25,15 @@ async function storeGroupVocabulary(
 
     await Promise.all(
       VocabularyCards.map(async (vocabularyCard) => {
-        const createdCard = await createVocabularyCard(
+        const createdCard = await createVocabularyCard({
           languagePackageId,
-          group.id,
-          vocabularyCard.name,
-          vocabularyCard.description,
+          groupId: group.id,
+          name: vocabularyCard.name,
+          description: vocabularyCard.description,
           userId,
           active,
-          activate
-        );
+          activate,
+        });
         // parse vocabulary card id from response and create translations
         createTranslations(vocabularyCard.Translations, userId, languagePackageId, createdCard.id);
       })

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -12,8 +12,6 @@ async function storeGroupVocabulary(
   active,
   activate
 ) {
-  const transaction = await sequelize.transaction();
-
   const languagePackage = await LanguagePackage.findOne({
     where: {
       userId,
@@ -24,6 +22,8 @@ async function storeGroupVocabulary(
   if (!languagePackage) {
     throw new ApiError(httpStatus.NOT_FOUND, 'language package not found');
   }
+
+  const transaction = await sequelize.transaction();
 
   try {
     const group = await Group.create(

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -72,12 +72,7 @@ async function storeGroupVocabulary(
     await transaction.commit();
   } catch (error) {
     await transaction.rollback();
-
-    if (error instanceof ForeignKeyConstraintError) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Error importing vocabs');
-    }
-
-    throw error;
+    throw new ApiError(httpStatus.BAD_REQUEST, 'Error importing vocabs');
   }
 }
 
@@ -119,7 +114,7 @@ async function storeLanguagePackageVocabulary(
       getDrawer = (oldId) => drawerMap[oldId];
     } else {
       const createdDrawers = await createDrawers(drawers, createdLanguagePackage.id, userId, transaction);
-      const drawer = createdDrawers.find((_drawer) => _drawer.stage === (activate ? 1 : 0));
+      const drawer = createdDrawers.find((_drawer) => +_drawer.stage === (activate ? 1 : 0));
 
       getDrawer = () => drawer;
     }
@@ -169,12 +164,7 @@ async function storeLanguagePackageVocabulary(
     await transaction.commit();
   } catch (error) {
     await transaction.rollback();
-
-    if (error instanceof ForeignKeyConstraintError) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Error importing vocabs');
-    }
-
-    throw error;
+    throw new ApiError(httpStatus.BAD_REQUEST, 'Error importing vocabs');
   }
 }
 

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -119,7 +119,7 @@ async function storeLanguagePackageVocabulary(
       getDrawer = (oldId) => drawerMap[oldId];
     } else {
       const createdDrawers = await createDrawers(drawers, createdLanguagePackage.id, userId, transaction);
-      const drawer = createdDrawers.find((_drawer) => _drawer.stage === (activate ? '1' : '0'));
+      const drawer = createdDrawers.find((_drawer) => _drawer.stage === (activate ? 1 : 0));
 
       getDrawer = () => drawer;
     }

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -97,8 +97,11 @@ async function storeLanguagePackageVocabulary(
               // when drawers are imported too, put new vocabs in imported stages
 
               drawerId: queryStatus
-                ? createdDrawers.find(
-                    (drawer) => drawer.stage === Drawers.find((element) => element.id === vocabularyCard.drawerId).stage
+                ? (
+                    createdDrawers.find(
+                      (drawer) =>
+                        drawer.stage === (Drawers.find((element) => element.id === vocabularyCard.drawerId) || {}).stage
+                    ) || {}
                   ).id
                 : null,
               userId,

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -1,0 +1,86 @@
+const { Group, LanguagePackage } = require('../../database');
+const ApiError = require('../utils/ApiError.js');
+const httpStatus = require('http-status');
+const { createDrawers } = require('./DrawerServiceProvider.js');
+const { createLanguagePackage } = require('./LanguagePackageServiceProvider.js');
+const { drawers } = require('../utils/constants.js');
+const { createVocabularyCard, createTranslations } = require('./VocabularyServiceProvider.js');
+
+async function storeGroupVocabulary(
+  { name, description, VocabularyCards },
+  userId,
+  languagePackageId,
+  active,
+  activate
+) {
+  const group = await Group.create({
+    userId,
+    languagePackageId,
+    name,
+    description,
+    active,
+  });
+
+  VocabularyCards.forEach(async (vocabularyCard) => {
+    const createdCard = await createVocabularyCard(
+      languagePackageId,
+      group.id,
+      vocabularyCard.name,
+      vocabularyCard.description,
+      userId,
+      active,
+      activate
+    );
+    // parse vocabulary card id from response and create translations
+    createTranslations(vocabularyCard.Translations, userId, languagePackageId, createdCard.id);
+  });
+}
+
+async function storeLanguagePackageVocabulary(
+  { name, foreignWordLanguage, translatedWordLanguage, vocabsPerDay, rightWords, Groups },
+  userId,
+  active,
+  activate
+) {
+  // ------------------------------------------//
+  // TO DO: ADD THESE TWO FUNCTIONS TOGETHER
+  // ------------------------------------------//
+
+  // create language Package
+  const createdLanguagePackage = await createLanguagePackage(
+    { name, foreignWordLanguage, translatedWordLanguage, vocabsPerDay, rightWords },
+    userId
+  );
+
+  // store drawers for language package in database
+  await createDrawers(drawers, createdLanguagePackage.id, userId);
+
+  Groups.forEach(async (group, index) => {
+    const createdGroup = await Group.create({
+      userId,
+      languagePackageId: createdLanguagePackage.id,
+      name: group.name,
+      description: group.description,
+      active,
+    });
+
+    Groups[index].VocabularyCards.forEach(async (vocabularyCard) => {
+      const createdCard = await createVocabularyCard(
+        createdLanguagePackage.id,
+        createdGroup.id,
+        vocabularyCard.name,
+        vocabularyCard.description,
+        userId,
+        active,
+        activate
+      );
+      // parse vocabulary card id from response and create translations
+      createTranslations(vocabularyCard.Translations, userId, createdLanguagePackage.id, createdCard.id);
+    });
+  });
+}
+
+module.exports = {
+  storeGroupVocabulary,
+  storeLanguagePackageVocabulary,
+};

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -1,11 +1,10 @@
-const { Group } = require('../../database');
+const { Group, VocabularyCard, Translation, Drawer, sequelize } = require('../../database');
 const { ForeignKeyConstraintError } = require('sequelize');
 const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
 const { createDrawers } = require('./DrawerServiceProvider.js');
 const { createLanguagePackage } = require('./LanguagePackageServiceProvider.js');
 const { drawers } = require('../utils/constants.js');
-const { createVocabularyCard, createTranslations } = require('./VocabularyServiceProvider.js');
 
 async function storeGroupVocabulary(
   { name, description, VocabularyCards },
@@ -14,31 +13,66 @@ async function storeGroupVocabulary(
   active,
   activate
 ) {
+  const transaction = await sequelize.transaction();
+
   try {
-    const group = await Group.create({
-      userId,
-      languagePackageId,
-      name,
-      description,
-      active,
+    const group = await Group.create(
+      {
+        userId,
+        languagePackageId,
+        name,
+        description,
+        active,
+      },
+      { transaction }
+    );
+
+    const drawer = await Drawer.findOne({
+      where: {
+        userId,
+        languagePackageId,
+        stage: activate ? 1 : 0,
+      },
+      transaction,
     });
+
+    const yesterday = new Date().setDate(new Date().getDate() - 1);
 
     await Promise.all(
       VocabularyCards.map(async (vocabularyCard) => {
-        const createdCard = await createVocabularyCard({
-          languagePackageId,
-          groupId: group.id,
-          name: vocabularyCard.name,
-          description: vocabularyCard.description,
-          userId,
-          active,
-          activate,
-        });
-        // parse vocabulary card id from response and create translations
-        createTranslations(vocabularyCard.Translations, userId, languagePackageId, createdCard.id);
+        await VocabularyCard.create(
+          {
+            userId,
+            languagePackageId,
+            groupId: group.id,
+            drawerId: drawer.id,
+            name: vocabularyCard.name,
+            description: vocabularyCard.description,
+            lastQuery: yesterday,
+            lastQueryCorrect: yesterday,
+            active,
+            Translations: vocabularyCard.Translations.map((translation) => ({
+              name: translation.name,
+              userId,
+              languagePackageId,
+            })),
+          },
+          {
+            transaction,
+            include: [
+              {
+                model: Translation,
+              },
+            ],
+          }
+        );
       })
     );
+
+    await transaction.commit();
   } catch (error) {
+    await transaction.rollback();
+
     if (error instanceof ForeignKeyConstraintError) {
       throw new ApiError(httpStatus.BAD_REQUEST, 'Error importing vocabs');
     }
@@ -54,67 +88,88 @@ async function storeLanguagePackageVocabulary(
   activate,
   queryStatus
 ) {
-  // ------------------------------------------//
-  // TO DO: ADD THESE TWO FUNCTIONS TOGETHER
-  // ------------------------------------------//
+  if (!Drawers && queryStatus) {
+    throw new ApiError(httpStatus.BAD_REQUEST, 'No exported drawers found');
+  }
+
+  const transaction = await sequelize.transaction();
 
   try {
-    if (!Drawers && queryStatus) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'No exported drawers found');
-    }
     // create language Package
     const createdLanguagePackage = await createLanguagePackage(
       { name, foreignWordLanguage, translatedWordLanguage, vocabsPerDay, rightWords },
-      userId
+      userId,
+      transaction
     );
 
-    let createdDrawers = [];
+    let getDrawer = () => null;
+    const yesterday = new Date().setDate(new Date().getDate() - 1);
 
-    if (queryStatus) {
-      createdDrawers = await createDrawers(Drawers, createdLanguagePackage.id, userId);
-    } else {
-      createdDrawers = await createDrawers(drawers, createdLanguagePackage.id, userId);
-    }
     // store drawers for language package in database
+    if (queryStatus) {
+      const createdDrawers = await createDrawers(Drawers, createdLanguagePackage.id, userId, transaction);
+      const drawerMap = Drawers.reduce(
+        (_drawerMap, oldDrawer, index) => ({
+          ..._drawerMap,
+          [oldDrawer.id]: createdDrawers[index],
+        }),
+        {}
+      );
+
+      getDrawer = (oldId) => drawerMap[oldId];
+    } else {
+      const createdDrawers = await createDrawers(drawers, createdLanguagePackage.id, userId, transaction);
+      const drawer = createdDrawers.find((_drawer) => _drawer.stage === (activate ? '1' : '0'));
+
+      getDrawer = () => drawer;
+    }
 
     await Promise.all(
-      Groups.map(async (group, index) => {
-        const createdGroup = await Group.create({
-          userId,
-          languagePackageId: createdLanguagePackage.id,
-          name: group.name,
-          description: group.description,
-          active,
-        });
-
-        await Promise.all(
-          Groups[index].VocabularyCards.map(async (vocabularyCard) => {
-            const createdCard = await createVocabularyCard({
+      Groups.map(async (group) => {
+        await Group.create(
+          {
+            userId,
+            languagePackageId: createdLanguagePackage.id,
+            name: group.name,
+            description: group.description,
+            active,
+            VocabularyCards: group.VocabularyCards.map((vocabularyCard) => ({
+              userId,
               languagePackageId: createdLanguagePackage.id,
-              groupId: createdGroup.id,
+              drawerId: queryStatus ? getDrawer(vocabularyCard.drawerId).id : getDrawer().id,
               name: vocabularyCard.name,
               description: vocabularyCard.description,
-              // when drawers are imported too, put new vocabs in imported stages
-
-              drawerId: queryStatus
-                ? (
-                    createdDrawers.find(
-                      (drawer) =>
-                        drawer.stage === (Drawers.find((element) => element.id === vocabularyCard.drawerId) || {}).stage
-                    ) || {}
-                  ).id
-                : null,
-              userId,
+              lastQuery: yesterday,
+              lastQueryCorrect: yesterday,
               active,
-              activate,
-            });
-            // parse vocabulary card id from response and create translations
-            createTranslations(vocabularyCard.Translations, userId, createdLanguagePackage.id, createdCard.id);
-          })
+              Translations: vocabularyCard.Translations.map((translation) => ({
+                name: translation.name,
+                userId,
+                languagePackageId: createdLanguagePackage.id,
+              })),
+            })),
+          },
+          {
+            transaction,
+            include: [
+              {
+                model: VocabularyCard,
+                include: [
+                  {
+                    model: Translation,
+                  },
+                ],
+              },
+            ],
+          }
         );
       })
     );
+
+    await transaction.commit();
   } catch (error) {
+    await transaction.rollback();
+
     if (error instanceof ForeignKeyConstraintError) {
       throw new ApiError(httpStatus.BAD_REQUEST, 'Error importing vocabs');
     }

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -1,5 +1,4 @@
 const { Group, VocabularyCard, Translation, Drawer, sequelize } = require('../../database');
-const { ForeignKeyConstraintError } = require('sequelize');
 const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
 const { createDrawers } = require('./DrawerServiceProvider.js');

--- a/app/Services/ImportServiceProvider.js
+++ b/app/Services/ImportServiceProvider.js
@@ -1,4 +1,4 @@
-const { Group, VocabularyCard, Translation, Drawer, sequelize } = require('../../database');
+const { Group, LanguagePackage, VocabularyCard, Translation, Drawer, sequelize } = require('../../database');
 const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
 const { createDrawers } = require('./DrawerServiceProvider.js');
@@ -13,6 +13,17 @@ async function storeGroupVocabulary(
   activate
 ) {
   const transaction = await sequelize.transaction();
+
+  const languagePackage = await LanguagePackage.findOne({
+    where: {
+      userId,
+      id: languagePackageId,
+    },
+  });
+
+  if (!languagePackage) {
+    throw new ApiError(httpStatus.NOT_FOUND, 'language package not found');
+  }
 
   try {
     const group = await Group.create(

--- a/app/Services/LanguagePackageServiceProvider.js
+++ b/app/Services/LanguagePackageServiceProvider.js
@@ -7,17 +7,21 @@ const httpStatus = require('http-status');
 // create language package
 async function createLanguagePackage(
   { name, foreignWordLanguage, translatedWordLanguage, vocabsPerDay, rightWords },
-  userId
+  userId,
+  transaction
 ) {
   try {
-    const languagePackage = await LanguagePackage.create({
-      userId,
-      name,
-      foreignWordLanguage,
-      translatedWordLanguage,
-      vocabsPerDay,
-      rightWords,
-    });
+    const languagePackage = await LanguagePackage.create(
+      {
+        userId,
+        name,
+        foreignWordLanguage,
+        translatedWordLanguage,
+        vocabsPerDay,
+        rightWords,
+      },
+      { transaction }
+    );
 
     return deleteKeysFromObject(['userId', 'createdAt', 'updatedAt'], languagePackage.toJSON());
   } catch (error) {

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -4,7 +4,7 @@ const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
 
 // create language package
-async function createVocabularyCard(languagePackageId, groupId, name, description, userId, active, activate) {
+async function createVocabularyCard({ languagePackageId, groupId, name, description, userId, active, activate }) {
   // if activate = false store vocabulary card in drawer 0 directly
 
   // select drawer id depending on the activate state

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -4,18 +4,32 @@ const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
 
 // create language package
-async function createVocabularyCard({ languagePackageId, groupId, name, description, userId, active, activate }) {
+async function createVocabularyCard({
+  languagePackageId,
+  groupId,
+  name,
+  description,
+  userId,
+  active,
+  activate,
+  drawerId,
+}) {
   // if activate = false store vocabulary card in drawer 0 directly
 
-  // select drawer id depending on the activate state
-  const drawer = await Drawer.findOne({
-    attributes: ['id'],
-    where: {
-      stage: activate ? 1 : 0,
-      languagePackageId,
-      userId,
-    },
-  });
+  // select drawer id depending on the activate and drawerId state
+  let drawer = {};
+  if (drawerId) {
+    drawer.id = drawerId;
+  } else {
+    drawer = await Drawer.findOne({
+      attributes: ['id'],
+      where: {
+        stage: activate ? 1 : 0,
+        languagePackageId,
+        userId,
+      },
+    });
+  }
 
   if (!drawer) {
     throw new ApiError(httpStatus.NOT_FOUND, 'no drawer found due to wrong language package id');

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -4,7 +4,7 @@ const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
 
 // create language package
-async function createVocabularyCard({ languagePackageId, groupId }, name, description, userId, active, activate) {
+async function createVocabularyCard(languagePackageId, groupId, name, description, userId, active, activate) {
   // if activate = false store vocabulary card in drawer 0 directly
 
   // select drawer id depending on the activate state

--- a/routes/api.js
+++ b/routes/api.js
@@ -13,6 +13,8 @@ const LanguageController = require('../app/Controllers/LanguageController.js');
 const DocsController = require('../app/Controllers/DocsController.js');
 const StatsController = require('../app/Controllers/StatsController.js');
 const InfoController = require('../app/Controllers/InfoController.js');
+const ImportController = require('../app/Controllers/ImportController.js');
+const ExportController = require('../app/Controllers/ExportController.js');
 
 const router = express.Router();
 
@@ -61,6 +63,10 @@ router.patch('/vocabulary/:vocabularyId', ProtectMiddleware, QueryController.che
 
 // Language
 router.get('/language', ProtectMiddleware, LanguageController.sendLanguages);
+
+// Import / Export
+router.get('/export/group/:groupId', ProtectMiddleware, ExportController.exportGroup);
+router.get('/export/languagePackage/:languagePackageId', ProtectMiddleware, ExportController.exportLanguagePackage);
 
 // Docs
 router.get('/swagger.json', DocsController.document);

--- a/routes/api.js
+++ b/routes/api.js
@@ -67,6 +67,8 @@ router.get('/language', ProtectMiddleware, LanguageController.sendLanguages);
 // Import / Export
 router.get('/export/group/:groupId', ProtectMiddleware, ExportController.exportGroup);
 router.get('/export/languagePackage/:languagePackageId', ProtectMiddleware, ExportController.exportLanguagePackage);
+router.post('/import/group/', ProtectMiddleware, ImportController.importGroup);
+router.post('/import/languagePackage/', ProtectMiddleware, ImportController.importLanguagePackage);
 
 // Docs
 router.get('/swagger.json', DocsController.document);

--- a/routes/api.js
+++ b/routes/api.js
@@ -65,10 +65,10 @@ router.patch('/vocabulary/:vocabularyId', ProtectMiddleware, QueryController.che
 router.get('/language', ProtectMiddleware, LanguageController.sendLanguages);
 
 // Import / Export
-router.get('/export/group/:groupId', ProtectMiddleware, ExportController.exportGroup);
-router.get('/export/languagePackage/:languagePackageId', ProtectMiddleware, ExportController.exportLanguagePackage);
-router.post('/import/group/', ProtectMiddleware, ImportController.importGroup);
-router.post('/import/languagePackage/', ProtectMiddleware, ImportController.importLanguagePackage);
+router.get('/group/:groupId/export', ProtectMiddleware, ExportController.exportGroup);
+router.get('/languagePackage/:languagePackageId/export', ProtectMiddleware, ExportController.exportLanguagePackage);
+router.post('/group/import', ProtectMiddleware, ImportController.importGroup);
+router.post('/languagePackage/import', ProtectMiddleware, ImportController.importLanguagePackage);
 
 // Docs
 router.get('/swagger.json', DocsController.document);

--- a/routes/api.js
+++ b/routes/api.js
@@ -67,8 +67,7 @@ router.get('/language', ProtectMiddleware, LanguageController.sendLanguages);
 // Import / Export
 router.get('/group/:groupId/export', ProtectMiddleware, ExportController.exportGroup);
 router.get('/languagePackage/:languagePackageId/export', ProtectMiddleware, ExportController.exportLanguagePackage);
-router.post('/group/import', ProtectMiddleware, ImportController.importGroup);
-router.post('/languagePackage/import', ProtectMiddleware, ImportController.importLanguagePackage);
+router.post('/import', ProtectMiddleware, ImportController.importVocabs);
 
 // Docs
 router.get('/swagger.json', DocsController.document);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
|  :white_check_mark: Ready | Feature | No |

## Description

<!--- Describe your changes in detail -->
Serverside implementation of the import/export function, which allows to add and store vocabs from a package or group from/in a JSON file.

To do:
- [x] import function
- [x] export function

<details>
<summary>

`GET /api/languagePackage/:languagePackageIdexport?queryStatus=false`

</summary>
<br>

Response
```json
{
    "name": "Englisch - German",
    "foreignWordLanguage": "en",
    "translatedWordLanguage": "de",
    "vocabsPerDay": 5,
    "rightWords": 2,
    "Groups": [
        {
            "name": "unit 1",
            "description": "",
            "VocabularyCards": [
                {
                    "name": "test vocab",
                    "description": "This is a test description",
                    "drawerId": "21e8e24d-5879-432f-b8bb-0db6cf38bb17",
                    "Translations": [
                        {
                            "name": "test translation"
                        }
                    ]
                },
                {
                    "name": "test vocab",
                    "description": "This is a test description",
                    "drawerId": "21e8e24d-5879-432f-b8bb-0db6cf38bb17",
                    "Translations": [
                        {
                            "name": "test translation"
                        }
                    ]
                },
                {
                    "name": "test vocab",
                    "description": "This is a test description",
                    "drawerId": "4f318312-84d6-4091-bcb1-cff4766266c9",
                    "Translations": [
                        {
                            "name": "test translation"
                        }
                    ]
                }
            ]
        }
    ],
    "Drawers": [
        {
            "id": "14f4c057-79da-4863-aa02-3bc918c0af45",
            "stage": 2,
            "queryInterval": 2
        },
        {
            "id": "ca7aadc8-9518-46ed-8652-aa57f315859e",
            "stage": 4,
            "queryInterval": 5
        },
        {
            "id": "ae1a7a74-15d6-45be-b66d-63907c4c1662",
            "stage": 7,
            "queryInterval": 60
        },
        {
            "id": "7bb1b5f2-1e55-457c-8a46-2b0a72a92c4a",
            "stage": 0,
            "queryInterval": 0
        },
        {
            "id": "4f318312-84d6-4091-bcb1-cff4766266c9",
            "stage": 1,
            "queryInterval": 1
        },
        {
            "id": "e31ee57c-27b2-4bb3-ba6c-46a7aab1cadf",
            "stage": 3,
            "queryInterval": 3
        },
        {
            "id": "cb03d329-08ae-4982-b30f-40d8f1b3fd71",
            "stage": 5,
            "queryInterval": 10
        },
        {
            "id": "d4f21553-3beb-48d9-b2c6-7a3cbd5b2274",
            "stage": 6,
            "queryInterval": 30
        },
        {
            "id": "21e8e24d-5879-432f-b8bb-0db6cf38bb17",
            "stage": 8,
            "queryInterval": 90
        }
    ]
}
```
</details>

<details>
<summary>

`GET /api/group/:groupId/export`

</summary>
<br>

Response
```json
{
    "name": "unit 1",
    "description": "",
    "VocabularyCards": [
        {
            "name": "test vocab",
            "description": "test description",
            "Translations": [
                {
                    "name": "test translation"
                }
            ]
        }
    ]
}
```
</details>

<details>
<summary>

`POST /api/import?active=true&activate=false&queryStatus=false  (PACKAGE)`

</summary>
<br>

Body (without imported query status)
```json
{
    "version": "v1.0.1",
    "type": "vocascan/package",
    "name": "English - German",
    "foreignWordLanguage": "en",
    "translatedWordLanguage": "de",
    "vocabsPerDay": 100,
    "rightWords": 2,
    "Groups": [
        {
            "name": "unit 1",
            "description": "",
            "VocabularyCards": [
                {
                    "name": "test vocab",
                    "description": "test description",
                    "Translations": [
                        {
                            "name": "test translation"
                        }
                    ]
                }
            ]
        }
    ]
}
```

Body (with imported query status)
when drawerId is not specified the "activate" property will be used to store the vocab card
```json
{
    "version": "v1.0.1",
    "type": "vocascan/package",
    "name": "Englisch - Deutsch",
    "foreignWordLanguage": "en",
    "translatedWordLanguage": "de",
    "vocabsPerDay": 5,
    "rightWords": 2,
    "Groups": [
        {
            "name": "unit 1",
            "description": "asfsfsf",
            "VocabularyCards": [
                {
                    "name": "test vocab",
                    "description": "This is a test description",
                    "drawerId": "cff3a3e2-3084-4950-a572-502e846a38b8"
                    "Translations": [
                        {
                            "name": "test translation"
                        }
                    ]
                },
                {
                    "name": "test vocab",
                    "description": "This is a test description",
                    "drawerId": "cff3a3e2-3084-4950-a572-502e846a38b8"
                    "Translations": [
                        {
                            "name": "test translation"
                        }
                    ]
                },
                {
                    "name": "test vocab",
                    "description": "This is a test description",
                    "drawerId": "36ec80d1-35d9-4404-8523-705b4919e91f", 
                    "Translations": [
                        {
                            "name": "test translation"
                        }
                    ]
                }
            ]
        }
    ],
    "Drawers": [
        {
            "id": "0b846944-5892-4205-b35e-da46264ac5ed",
            "stage": 0,
            "queryInterval": 0
        },
        {
            "id": "36ec80d1-35d9-4404-8523-705b4919e91f",
            "stage": 1,
            "queryInterval": 1
        },
        {
            "id": "be4c9336-faa3-47b5-bc33-cff177695d95",
            "stage": 2,
            "queryInterval": 2
        },
        {
            "id": "dccd2ff5-6810-4391-b17e-b2fd7976054c",
            "stage": 3,
            "queryInterval": 3
        },
        {
            "id": "2cde6dd1-62fd-4e0a-8b98-bcc99caa2c93",
            "stage": 4,
            "queryInterval": 5
        },
        {
            "id": "af37655d-f8c7-4d90-8d5f-5a69d79389ff",
            "stage": 5,
            "queryInterval": 10
        },
        {
            "id": "d831529a-4cf5-4953-a678-1bd87038bbc2",
            "stage": 6,
            "queryInterval": 30
        },
        {
            "id": "10bee574-feb4-4b5a-9cd5-2d32d18c2450",
            "stage": 7,
            "queryInterval": 60
        },
        {
            "id": "cff3a3e2-3084-4950-a572-502e846a38b8",
            "stage": 8,
            "queryInterval": 90
        }
    ]
}
```
</details>

<details>
<summary>

`POST /api/import?languagePackageId&active&activate  (GROUP)`

</summary>
<br>

Body
```json
{
    "name": "unit 1",
    "description": "",
    "VocabularyCards": [
        {
            "name": "test vocab",
            "description": "test description",
            "Translations": [
                {
                    "name": "test translation"
                }
            ]
        },
    ]
}
```
</details>





## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We wanted to have import and export functions to share vocabs among each other, or simply transfer them to another server, by exporting them with their current query status

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
