### PR TITLE
fix: swagger doc url behind reverse proxy

### DIFF
--- a/app/Controllers/DocsController.js
+++ b/app/Controllers/DocsController.js
@@ -1,6 +1,7 @@
 const swaggerUi = require('swagger-ui-express');
 
 const swaggerDocument = require('../../docs/api/swagger.json');
+const { getVersion } = require('../Services/InfoServiceProvider');
 
 // disable swagger topbar
 const swaggerOptions = {
@@ -9,28 +10,13 @@ const swaggerOptions = {
   `,
 };
 
-const injectHostMiddleware = (req, _res, next) => {
-  req.swaggerDoc = swaggerDocument;
+swaggerDocument.info.version = getVersion();
 
-  // get url
-  const currentURL = `${req.protocol}://${req.get('host')}/api`;
+const swagger = [swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerOptions)];
 
-  // inject host
-  if (req.swaggerDoc.servers[0].description !== 'current') {
-    req.swaggerDoc.servers = [{ description: 'current', url: currentURL }, ...req.swaggerDoc.servers];
-  }
-
-  next();
+const document = (_req, res) => {
+  res.json(swaggerDocument);
 };
-
-const swagger = [injectHostMiddleware, swaggerUi.serve, swaggerUi.setup(swaggerDocument, swaggerOptions)];
-
-const document = [
-  injectHostMiddleware,
-  (req, res) => {
-    res.json(req.swaggerDoc);
-  },
-];
 
 module.exports = {
   swagger,

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -5,10 +5,20 @@
         "description": "A highly configurable vocabulary trainer.",
         "version": "1.0.0"
     },
-    "servers": [{
-        "description": "localhost",
-        "url": "http://localhost:5000/api"
-    }],
+    "servers": [
+        {
+            "description": "current",
+            "url": "/api"
+        },
+        {
+            "description": "localhost",
+            "url": "http://localhost:5000/api"
+        }
+    ],
+    "externalDocs": {
+        "url": "https://docs.vocascan.com",
+        "description": "Vocascan Documentation"
+    },
     "paths": {
         "/swagger.json": {
             "get": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: | 
| :white_check_mark: Ready | Bug| No |

## Description

Fix bug if server is behind a reverse proxy the swagger current server url was wrong.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
