### PR TITLE
v1.0.1: Fixed role seeders for MySQL setup

### DIFF
--- a/database/seeders/0001.roles.js
+++ b/database/seeders/0001.roles.js
@@ -4,14 +4,14 @@ const roles = [
   {
     id: uuid(),
     name: 'user',
-    adminRights: 'false',
+    adminRights: false,
     createdAt: new Date(),
     updatedAt: new Date(),
   },
   {
     id: uuid(),
     name: 'admin',
-    adminRights: 'true',
+    adminRights: true,
     createdAt: new Date(),
     updatedAt: new Date(),
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| :white_check_mark: Ready | Hotfix | Yes |

## Description

<!--- Describe your changes in detail -->
This PR will fix the Issue vocascan/documentation#2 that occurs with role seeders in a MySQL database, which can't parse strings to boolean automatically as it seems.

Successfully tested with:
- [x] PostgreSQL
- [x] MariaDb
- [x] MySQL
- [x] SQlite

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
