### PR TITLE
enable logger option

### DIFF
--- a/app/config/config/index.js
+++ b/app/config/config/index.js
@@ -40,6 +40,9 @@ const parseConfig = ({ configPath, extraConfig = {} } = {}) => {
   const mergedConfigWithDefaultKeys = {
     server: {},
     database: {},
+    log: {
+      console: { colorize: true },
+    },
     api: {},
     ...mergedConfig,
   };

--- a/app/config/config/schema.js
+++ b/app/config/config/schema.js
@@ -3,6 +3,7 @@ const { logTransportTypes, logLevels } = require('../../utils/constants');
 
 // sub schemas
 const logSchema = Joi.object({
+  enable: Joi.boolean().default(true),
   mode: Joi.string()
     .valid(...Object.values(logTransportTypes))
     .default('console'),

--- a/vocascan.config.example.js
+++ b/vocascan.config.example.js
@@ -26,6 +26,7 @@ module.exports = {
 
   log: {
     my_console_logger: {
+      enable: true,
       mode: 'console',
       level: 'info',
       colorize: true,
@@ -42,6 +43,7 @@ module.exports = {
       stderr_levels: ['error'],
     },
     file: {
+      enable: true,
       mode: 'file',
       level: 'info',
       enable_sql_log: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| :white_check_mark: Ready | Feature| Yes |

## Description

This PR adds a `log.<name>.enable` option which defines, if the logger is active. This is useful to disable the by default enabled console logger. (`VOCASCAN__LOG__CONSOLE__ENABLE=false`)

Documentation added in vocascan/documentation#10

<!--- Describe your changes in detail -->

## Motivation and Context

It was a pain to configure the logger every time, and if i forgot, i never noticed it right away.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
