### PR TITLE
Feature/legal templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vocascan.config.*
 !docker/**/vocascan.config.*
 docker/**/database
 *.log
+/staticPages

--- a/app/Controllers/StaticPagesController.js
+++ b/app/Controllers/StaticPagesController.js
@@ -1,10 +1,9 @@
 const catchAsync = require('../utils/catchAsync');
-const path = require('path');
 const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
 
-const renderHandler = catchAsync(async (res, page) => {
-  const options = { root: path.join(__dirname, '../../') };
+const renderPageHandler = catchAsync(async (res, page) => {
+  const options = { root: process.cwd() };
 
   // check if page should be rendered from a static file or should be redirected to another one
   if (page.type === 'file') {
@@ -18,30 +17,29 @@ const renderHandler = catchAsync(async (res, page) => {
   }
 });
 
-const renderPage = catchAsync(async (req, res, pageValues) => {
-  // check which language the user wants his page
-  const language = req.query.lang;
+const getRenderPageHandler = (pageValues) =>
+  catchAsync(async (req, res) => {
+    // check which language the user wants his page
+    const language = req.query.lang;
 
-  // if no language is given, render fallback page
-  if (!language) {
-    const fallbackPage = pageValues.fallback;
+    // if no language is given, render fallback page
+    if (!language) {
+      renderPageHandler(res, pageValues.fallback);
 
-    renderHandler(res, fallbackPage);
+      return;
+    }
 
-    return;
-  }
-
-  const languagePage = pageValues.langs[language];
-  // check if key (language) is available
-  if (languagePage) {
-    renderHandler(res, languagePage);
-  }
-  // requested page language is not defined by host, redirect to fallback page
-  else {
-    res.redirect(pageValues.url);
-  }
-});
+    const languagePage = pageValues.langs[language];
+    // check if key (language) is available
+    if (languagePage) {
+      renderPageHandler(res, languagePage);
+    }
+    // requested page language is not defined by host, redirect to fallback page
+    else {
+      res.redirect(pageValues.url);
+    }
+  });
 
 module.exports = {
-  renderPage,
+  getRenderPageHandler,
 };

--- a/app/Controllers/StaticPagesController.js
+++ b/app/Controllers/StaticPagesController.js
@@ -12,8 +12,10 @@ const renderPageHandler = catchAsync(async (res, page) => {
         throw new ApiError(httpStatus.NOT_FOUND, 'Page was not found');
       }
     });
-  } else {
+  } else if (page.type === 'redirect') {
     res.redirect(page.location);
+  } else {
+    throw new ApiError(httpStatus.NOT_FOUND, 'Unknown page type');
   }
 });
 

--- a/app/Controllers/StaticPagesController.js
+++ b/app/Controllers/StaticPagesController.js
@@ -23,13 +23,14 @@ const getRenderPageHandler = (pageValues) =>
     const language = req.query.lang;
 
     // if no language is given, render fallback page
-    if (!language) {
+    if (!language || !pageValues.langs) {
       renderPageHandler(res, pageValues.fallback);
 
       return;
     }
 
     const languagePage = pageValues.langs[language];
+
     // check if key (language) is available
     if (languagePage) {
       renderPageHandler(res, languagePage);

--- a/app/Controllers/StaticPagesController.js
+++ b/app/Controllers/StaticPagesController.js
@@ -1,0 +1,30 @@
+const catchAsync = require('../utils/catchAsync');
+const path = require('path');
+
+const renderPage = catchAsync(async (req, res, pageValues) => {
+  // check which language the user wants his page
+  const language = req.query.lang;
+  const options = { root: path.join(__dirname, '../../') };
+  // check if key (language) is available
+  if (Object.prototype.hasOwnProperty.call(pageValues.langs, language)) {
+    if (pageValues.langs[language].file) {
+      res.sendFile(pageValues.langs[language].file, options);
+    }
+    // if key is not "file" make a redirect
+    else {
+      res.redirect(pageValues.langs[language].redirect);
+    }
+  }
+  // requested page language is not defined by host, use fallback page
+  else if (pageValues.fallback.file) {
+    res.sendFile(pageValues.fallback.file, options);
+  }
+  // if key is not "file" make a redirect
+  else {
+    res.redirect(pageValues.fallback.redirect);
+  }
+});
+
+module.exports = {
+  renderPage,
+};

--- a/app/Controllers/StaticPagesController.js
+++ b/app/Controllers/StaticPagesController.js
@@ -1,27 +1,44 @@
 const catchAsync = require('../utils/catchAsync');
 const path = require('path');
+const ApiError = require('../utils/ApiError.js');
+const httpStatus = require('http-status');
+
+const renderHandler = catchAsync(async (res, page) => {
+  const options = { root: path.join(__dirname, '../../') };
+
+  // check if page should be rendered from a static file or should be redirected to another one
+  if (page.type === 'file') {
+    res.sendFile(page.location, options, (err) => {
+      if (err) {
+        throw new ApiError(httpStatus.NOT_FOUND, 'Page was not found');
+      }
+    });
+  } else {
+    res.redirect(page.location);
+  }
+});
 
 const renderPage = catchAsync(async (req, res, pageValues) => {
   // check which language the user wants his page
   const language = req.query.lang;
-  const options = { root: path.join(__dirname, '../../') };
+
+  // if no language is given, render fallback page
+  if (!language) {
+    const fallbackPage = pageValues.fallback;
+
+    renderHandler(res, fallbackPage);
+
+    return;
+  }
+
+  const languagePage = pageValues.langs[language];
   // check if key (language) is available
-  if (Object.prototype.hasOwnProperty.call(pageValues.langs, language)) {
-    if (pageValues.langs[language].file) {
-      res.sendFile(pageValues.langs[language].file, options);
-    }
-    // if key is not "file" make a redirect
-    else {
-      res.redirect(pageValues.langs[language].redirect);
-    }
+  if (languagePage) {
+    renderHandler(res, languagePage);
   }
-  // requested page language is not defined by host, use fallback page
-  else if (pageValues.fallback.file) {
-    res.sendFile(pageValues.fallback.file, options);
-  }
-  // if key is not "file" make a redirect
+  // requested page language is not defined by host, redirect to fallback page
   else {
-    res.redirect(pageValues.fallback.redirect);
+    res.redirect(pageValues.url);
   }
 });
 

--- a/app/config/config/schema.js
+++ b/app/config/config/schema.js
@@ -81,6 +81,26 @@ const configSchema = Joi.object({
   api: Joi.object({
     enable_swagger: Joi.boolean().default(true),
   }).default({}),
+
+  pages: Joi.object({
+    privacy: Joi.object({
+      url: Joi.string(),
+      fallback: Joi.object({
+        type: Joi.string(),
+        location: Joi.string(),
+      }),
+      langs: Joi.object({
+        en: Joi.object({
+          type: Joi.string(),
+          location: Joi.string(),
+        }),
+        de: Joi.object({
+          type: Joi.string(),
+          location: Joi.string(),
+        }),
+      }),
+    }),
+  }),
 });
 
 module.exports = configSchema;

--- a/app/config/config/schema.js
+++ b/app/config/config/schema.js
@@ -35,6 +35,11 @@ const logSchema = Joi.object({
   archive_logs: Joi.boolean().when('mode', { is: 'file', otherwise: Joi.forbidden() }),
 });
 
+const renderPageSchema = Joi.object({
+  type: Joi.string().valid('file', 'redirect').required(),
+  location: Joi.string().required(),
+}).required();
+
 // main schema
 const configSchema = Joi.object({
   debug: Joi.boolean().default(false),
@@ -82,25 +87,16 @@ const configSchema = Joi.object({
     enable_swagger: Joi.boolean().default(true),
   }).default({}),
 
-  pages: Joi.object({
-    privacy: Joi.object({
-      url: Joi.string(),
-      fallback: Joi.object({
-        type: Joi.string(),
-        location: Joi.string(),
-      }),
-      langs: Joi.object({
-        en: Joi.object({
-          type: Joi.string(),
-          location: Joi.string(),
-        }),
-        de: Joi.object({
-          type: Joi.string(),
-          location: Joi.string(),
-        }),
-      }),
-    }),
-  }),
+  pages: Joi.object()
+    .unknown()
+    .pattern(
+      Joi.string(),
+      Joi.object({
+        url: Joi.string().required(),
+        fallback: renderPageSchema,
+        langs: Joi.object().unknown().pattern(Joi.string(), renderPageSchema),
+      })
+    ),
 });
 
 module.exports = configSchema;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,12 +1,15 @@
 const express = require('express');
 
 const APIRouter = require('./api');
+const PageRouter = require('./pages');
 
 const router = express.Router();
 
 router.get('/', (_req, res) => {
   res.send('Hello World!');
 });
+
+router.use('/', PageRouter);
 
 router.use('/api', APIRouter);
 

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -7,11 +7,9 @@ const StaticPagesController = require('../app/Controllers/StaticPagesController.
 const router = express.Router();
 
 if (config.pages) {
-  for (const [, value] of Object.entries(config.pages)) {
-    router.get(value.url, (req, res) => {
-      StaticPagesController.renderPage(req, res, value);
-    });
-  }
+  Object.values(config.pages).forEach((page) => {
+    router.get(page.url, StaticPagesController.getRenderPageHandler(page));
+  });
 }
 
 module.exports = router;

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -1,0 +1,17 @@
+const express = require('express');
+
+const config = require('../app/config/config');
+
+const StaticPagesController = require('../app/Controllers/StaticPagesController.js');
+
+const router = express.Router();
+
+if (config.pages) {
+  for (const [, value] of Object.entries(config.pages)) {
+    router.get(value.url, (req, res) => {
+      StaticPagesController.renderPage(req, res, value);
+    });
+  }
+}
+
+module.exports = router;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

|               Status                |                Type                 | Env Vars Change |
| :---------------------------------: | :---------------------------------: | :-------------: |
| :white_check_mark: Ready | Feature |     Yes      |

## Description

This PR adds the function to create your own routes and add static pages or redirects to your server in them. Mainly to include a privacy policy and terms and conditions.

just define your custom pages in the config (documentation will be done soon)

```js
// ...
pages: {
    privacy: {
      url: '/privacy',
      fallback: { type: 'file', location: './staticPages/privacy-en.html' },
      langs: {
        en: { type: 'redirect', location: 'https://my-website/privacy' },
        de: { type: 'file', location: './staticPages/privacy-de.html' },
        // ...
      },
    },
   termsAndConditions: {
      url: '/terms-and-conditions',
      fallback: { type: 'file', location: './staticPages/privacy-en.html' },
      langs: {
        en: { type: 'redirect', location: 'https://my-website/privacy' },
        // ...
      },
    },
  },
```

Info: The ``langs`` prop is not required.

In this case ``/privacy`` and ``/terms-and-conditions`` would return or redirect the fallback page, as no language is given in the query params. If you add ``?lang=en`` the page, defined in ``langs`` will be displayed. 

To Do:
- [x] Joi schema

If you use a language as query parameter, that is not defined in the config, you will be redirected to the fallback page.

<!--- Describe your changes in detail -->

## Motivation and Context

We will need this function to bring the Vocascan Cloud one step closer to the public

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
