### PR TITLE
Refactor: Routes for group specific vocab activation

### DIFF
--- a/app/Controllers/GroupController.js
+++ b/app/Controllers/GroupController.js
@@ -24,13 +24,15 @@ const sendGroups = catchAsync(async (req, res) => {
 
   // decide if we have to fetch stats
   const includeStats = (req.query.stats || false) === 'true';
+  const onlyStaged = (req.query.staged || false) === 'true';
 
   // get groups
-  const groups = await getGroups(userId, languagePackageId);
+  const groups = await getGroups(userId, languagePackageId, onlyStaged);
 
   const formatted = await Promise.all(
     groups.map(async (group) => ({
-      ...group.toJSON(),
+      // if onlyStaged return just group, as response has already been prepared
+      ...(onlyStaged ? group : { ...group.toJSON() }),
 
       ...(includeStats
         ? {

--- a/app/Controllers/GroupController.js
+++ b/app/Controllers/GroupController.js
@@ -37,7 +37,7 @@ const sendGroups = catchAsync(async (req, res) => {
   const groups = await getGroups(userId, languagePackageId, onlyStaged, onlyActivated);
   const formatted = await Promise.all(
     groups.map(async (group) => ({
-      // if onlyStaged return just group, as response has already been prepared
+      // if onlyStaged or onlyActivated return just group, as response has already been prepared
       ...(onlyStaged || onlyActivated ? group : { ...group.toJSON() }),
       ...(includeStats
         ? {

--- a/app/Controllers/GroupController.js
+++ b/app/Controllers/GroupController.js
@@ -35,7 +35,6 @@ const sendGroups = catchAsync(async (req, res) => {
 
   // get groups
   const groups = await getGroups(userId, languagePackageId, onlyStaged, onlyActivated);
-  console.log('not formatted');
   const formatted = await Promise.all(
     groups.map(async (group) => ({
       // if onlyStaged return just group, as response has already been prepared
@@ -51,8 +50,6 @@ const sendGroups = catchAsync(async (req, res) => {
         : {}),
     }))
   );
-
-  console.log('formatted');
   res.send(formatted);
 });
 

--- a/app/Controllers/LanguagePackageController.js
+++ b/app/Controllers/LanguagePackageController.js
@@ -28,9 +28,10 @@ const sendLanguagePackages = catchAsync(async (req, res) => {
   const userId = req.user.id;
   const includeGroups = (req.query.groups || false) === 'true';
   const includeStats = (req.query.stats || false) === 'true';
+  const onlyActivated = (req.query.onlyActivated || false) === 'true';
 
   // get language Package
-  const languagePackages = await getLanguagePackages(userId, includeGroups);
+  const languagePackages = await getLanguagePackages(userId, includeGroups, onlyActivated);
 
   const formatted = await Promise.all(
     languagePackages.map(async (languagePackage) => ({

--- a/app/Controllers/QueryController.js
+++ b/app/Controllers/QueryController.js
@@ -59,6 +59,7 @@ const sendQueryVocabulary = catchAsync(async (req, res) => {
     res.send(vocabulary);
   }
 
+  // regular daily query
   if (!onlyStaged && !onlyActivated && !groupId) {
     // if no groups are set, just return vocabs depending on the learning algorithm
     const vocabulary = await getQueryVocabulary(languagePackageId, userId, limit);

--- a/app/Controllers/QueryController.js
+++ b/app/Controllers/QueryController.js
@@ -27,9 +27,9 @@ const sendQueryVocabulary = catchAsync(async (req, res) => {
     }
   }
 
-  // if groups are set return vocabs of group independ from their current stage
-  // (used for vocab acitvation and custom learning)
+  // only staged vocabs
   if (onlyStaged) {
+    // if group ids are set, only return staged vocabs from that groups
     if (groupId) {
       // specific vocab activation
       const vocabulary = await getUnactivatedVocabulary(languagePackageId, userId, groupId);
@@ -41,26 +41,20 @@ const sendQueryVocabulary = catchAsync(async (req, res) => {
     }
   }
 
-  if (onlyActivated) {
-    if (groupId) {
-      // custom learning with only activated vocabs
-      const vocabulary = await getGroupsVocabulary(userId, groupId, false, true);
-      res.send(vocabulary);
-    } else {
-      // custom learning
-      const vocabulary = await getGroupsVocabulary(userId, groupId, false, false);
-      res.send(vocabulary);
-    }
+  // custom learning with only activated vocabs
+  if (!onlyStaged && onlyActivated && groupId) {
+    const vocabulary = await getGroupsVocabulary(userId, groupId, false, true, true);
+    res.send(vocabulary);
   }
 
+  // custom learning with activated and staged vocabs
   if (!onlyStaged && !onlyActivated && groupId) {
-    // custom learning with activated and staged vocabs
-    const vocabulary = await getGroupsVocabulary(userId, groupId, false, false);
+    const vocabulary = await getGroupsVocabulary(userId, groupId, false, false, true);
     res.send(vocabulary);
   }
 
   // regular daily query
-  if (!onlyStaged && !onlyActivated && !groupId) {
+  if (!onlyStaged && onlyActivated && !groupId) {
     // if no groups are set, just return vocabs depending on the learning algorithm
     const vocabulary = await getQueryVocabulary(languagePackageId, userId, limit);
     res.send(vocabulary);

--- a/app/Controllers/QueryController.js
+++ b/app/Controllers/QueryController.js
@@ -39,9 +39,11 @@ const sendQueryVocabulary = catchAsync(async (req, res) => {
       const vocabulary = await getUnactivatedVocabulary(languagePackageId, userId, groupId);
       res.send(vocabulary);
     }
-  } else if (onlyActivated) {
+  }
+
+  if (onlyActivated) {
     if (groupId) {
-      // custom learning
+      // custom learning with only activated vocabs
       const vocabulary = await getGroupsVocabulary(userId, groupId, false, true);
       res.send(vocabulary);
     } else {
@@ -49,7 +51,15 @@ const sendQueryVocabulary = catchAsync(async (req, res) => {
       const vocabulary = await getGroupsVocabulary(userId, groupId, false, false);
       res.send(vocabulary);
     }
-  } else {
+  }
+
+  if (!onlyStaged && !onlyActivated && groupId) {
+    // custom learning with activated and staged vocabs
+    const vocabulary = await getGroupsVocabulary(userId, groupId, false, false);
+    res.send(vocabulary);
+  }
+
+  if (!onlyStaged && !onlyActivated && !groupId) {
     // if no groups are set, just return vocabs depending on the learning algorithm
     const vocabulary = await getQueryVocabulary(languagePackageId, userId, limit);
     res.send(vocabulary);

--- a/app/Controllers/QueryController.js
+++ b/app/Controllers/QueryController.js
@@ -22,7 +22,7 @@ const sendQueryVocabulary = catchAsync(async (req, res) => {
 
   // convert groups to Array, if only one group was sent. Express is storing it a string instead of an Array
   if (!Array.isArray(groupId)) {
-    if (groupId != null) {
+    if (groupId !== null) {
       groupId = [groupId];
     }
   }

--- a/app/Controllers/VocabularyController.js
+++ b/app/Controllers/VocabularyController.js
@@ -50,7 +50,7 @@ const sendGroupVocabulary = catchAsync(async (req, res) => {
   const userId = req.user.id;
   const { groupId } = req.params;
   const { search } = req.query;
-  const onlyStaged = (req.query.staged || false) === 'true';
+  const onlyStaged = (req.query.onlyStaged || false) === 'true';
 
   const vocabulary = await getGroupVocabulary(userId, groupId, search, onlyStaged);
 

--- a/app/Controllers/VocabularyController.js
+++ b/app/Controllers/VocabularyController.js
@@ -50,8 +50,9 @@ const sendGroupVocabulary = catchAsync(async (req, res) => {
   const userId = req.user.id;
   const { groupId } = req.params;
   const { search } = req.query;
+  const onlyStaged = (req.query.staged || false) === 'true';
 
-  const vocabulary = await getGroupVocabulary(userId, groupId, search);
+  const vocabulary = await getGroupVocabulary(userId, groupId, search, onlyStaged);
 
   res.send(vocabulary);
 });

--- a/app/Services/GroupServiceProvider.js
+++ b/app/Services/GroupServiceProvider.js
@@ -46,20 +46,12 @@ async function getGroups(userId, languagePackageId, onlyStaged) {
           },
         ]
       : null,
-    ...(onlyStaged
-      ? {
-          where: {
-            userId,
-            languagePackageId,
-            '$VocabularyCards.Drawer.stage$': 0,
-          },
-        }
-      : {
-          where: {
-            userId,
-            languagePackageId,
-          },
-        }),
+
+    where: {
+      userId,
+      languagePackageId,
+      ...(onlyStaged ? { '$VocabularyCards.Drawer.stage$': 0 } : null),
+    },
   });
 
   // if onlyStaged, remove VocabularyCards from response

--- a/app/Services/GroupServiceProvider.js
+++ b/app/Services/GroupServiceProvider.js
@@ -29,8 +29,6 @@ async function getGroups(userId, languagePackageId, onlyStaged, onlyActivated) {
     throw new ApiError(httpStatus.NOT_FOUND, 'no groups found, because the language package does not exist');
   }
 
-  console.log('!!!! searching groups !!!!!');
-
   // if only groups with staged vocabs should be returned, include vocabs with drawer stages to validate
   const groups = await Group.findAll({
     attributes: ['id', 'languagePackageId', 'name', 'description', 'active'],
@@ -57,8 +55,6 @@ async function getGroups(userId, languagePackageId, onlyStaged, onlyActivated) {
       ...(onlyActivated && { '$VocabularyCards.active$': true } ? { '$VocabularyCards.Drawer.stage$': !0 } : null),
     },
   });
-
-  console.log('!!!! Groups found !!!!!');
 
   // if onlyStaged or onlyActivated, remove VocabularyCards from response
   return onlyStaged || onlyActivated

--- a/app/Services/GroupServiceProvider.js
+++ b/app/Services/GroupServiceProvider.js
@@ -1,4 +1,4 @@
-const { LanguagePackage, Group } = require('../../database');
+const { LanguagePackage, Group, VocabularyCard, Drawer } = require('../../database');
 const { deleteKeysFromObject } = require('../utils');
 const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
@@ -17,7 +17,7 @@ async function createGroup({ name, description, active }, userId, languagePackag
 }
 
 // get groups
-async function getGroups(userId, languagePackageId) {
+async function getGroups(userId, languagePackageId, onlyStaged) {
   const languagePackage = await LanguagePackage.count({
     where: {
       id: languagePackageId,
@@ -29,15 +29,41 @@ async function getGroups(userId, languagePackageId) {
     throw new ApiError(httpStatus.NOT_FOUND, 'no groups found, because the language package does not exist');
   }
 
+  // if only groups with staged vocabs should be returned, include vocabs with drawer stages to validate
   const groups = await Group.findAll({
     attributes: ['id', 'languagePackageId', 'name', 'description', 'active'],
-    where: {
-      userId,
-      languagePackageId,
-    },
+    include: onlyStaged
+      ? [
+          {
+            model: VocabularyCard,
+            attributes: [],
+            include: [
+              {
+                model: Drawer,
+                attributes: ['stage'],
+              },
+            ],
+          },
+        ]
+      : null,
+    ...(onlyStaged
+      ? {
+          where: {
+            userId,
+            languagePackageId,
+            '$VocabularyCards.Drawer.stage$': 0,
+          },
+        }
+      : {
+          where: {
+            userId,
+            languagePackageId,
+          },
+        }),
   });
 
-  return groups;
+  // if onlyStaged, remove VocabularyCards from response
+  return onlyStaged ? groups.map((group) => deleteKeysFromObject(['VocabularyCards'], group.dataValues)) : groups;
 }
 
 async function destroyGroup(userId, groupId) {

--- a/app/Services/QueryServiceProvider.js
+++ b/app/Services/QueryServiceProvider.js
@@ -122,11 +122,9 @@ async function getUnactivatedVocabulary(languagePackageId, userId, groupIds) {
       active: true,
       ...(groupIds
         ? {
-            [Op.or]: [
-              groupIds.map((groupId) => {
-                return { '$Group.id$': groupId };
-              }),
-            ],
+            groupId: {
+              [Op.or]: [groupIds],
+            },
           }
         : null),
     },

--- a/app/Services/QueryServiceProvider.js
+++ b/app/Services/QueryServiceProvider.js
@@ -81,7 +81,7 @@ async function getQueryVocabulary(languagePackageId, userId, limit) {
 }
 
 // return the unactivated vocabulary
-async function getUnactivatedVocabulary(languagePackageId, userId) {
+async function getUnactivatedVocabulary(languagePackageId, userId, groupIds) {
   // Get drawers id
   const drawer = await Drawer.findOne({
     attributes: ['id'],
@@ -120,6 +120,15 @@ async function getUnactivatedVocabulary(languagePackageId, userId) {
       drawerId: drawer.id,
       '$Group.active$': true,
       active: true,
+      ...(groupIds
+        ? {
+            [Op.or]: [
+              groupIds.map((groupId) => {
+                return { '$Group.id$': groupId };
+              }),
+            ],
+          }
+        : null),
     },
   });
 

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -125,7 +125,7 @@ async function getGroupVocabulary(userId, groupId, search, onlyStaged) {
 // this function is the same as getGroupVocabulary, but for multiple group ids and without search functionality
 // Because we don't use TypeScript watch out which one you use
 // TODO: Maybe I will add those two functions together one time
-async function getGroupsVocabulary(userId, groupIds, onlyStaged) {
+async function getGroupsVocabulary(userId, groupIds, onlyStaged, onlyActivated) {
   groupIds.map(async (groupId) => {
     const group = await Group.count({
       where: {
@@ -154,6 +154,11 @@ async function getGroupsVocabulary(userId, groupIds, onlyStaged) {
     where: {
       userId,
       ...(onlyStaged ? { '$Drawer.stage$': 0 } : null),
+      ...(onlyActivated
+        ? sequelize.where('$Drawer.stage$', {
+            [Op.gt]: 0,
+          })
+        : null),
       groupId: {
         [Op.or]: [groupIds],
       },

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -2,8 +2,7 @@ const { VocabularyCard, Translation, Drawer, Group } = require('../../database')
 const { deleteKeysFromObject } = require('../utils');
 const ApiError = require('../utils/ApiError.js');
 const httpStatus = require('http-status');
-const sequelize = require('sequelize');
-const { Op } = sequelize;
+const { Sequelize, Op } = require('sequelize');
 
 // create language package
 async function createVocabularyCard({
@@ -107,10 +106,10 @@ async function getGroupVocabulary(userId, groupId, search, onlyStaged) {
         },
         search && {
           [Op.or]: [
-            sequelize.where(sequelize.fn('lower', sequelize.col('VocabularyCard.name')), {
+            Sequelize.where(Sequelize.fn('lower', Sequelize.col('VocabularyCard.name')), {
               [Op.like]: `%${search.toLowerCase()}%`,
             }),
-            sequelize.where(sequelize.fn('lower', sequelize.col('Translations.name')), {
+            Sequelize.where(Sequelize.fn('lower', Sequelize.col('Translations.name')), {
               [Op.like]: `%${search.toLowerCase()}%`,
             }),
           ],
@@ -125,7 +124,7 @@ async function getGroupVocabulary(userId, groupId, search, onlyStaged) {
 // this function is the same as getGroupVocabulary, but for multiple group ids and without search functionality
 // Because we don't use TypeScript watch out which one you use
 // TODO: Maybe I will add those two functions together one time
-async function getGroupsVocabulary(userId, groupIds, onlyStaged, onlyActivated) {
+async function getGroupsVocabulary(userId, groupIds, onlyStaged, onlyActivated, random) {
   groupIds.map(async (groupId) => {
     const group = await Group.count({
       where: {
@@ -150,6 +149,7 @@ async function getGroupsVocabulary(userId, groupIds, onlyStaged, onlyActivated) 
         attributes: ['stage'],
       },
     ],
+    order: random ? Sequelize.literal('random()') : null,
     attributes: ['id', 'name', 'active', 'description'],
     where: {
       userId,

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -154,11 +154,9 @@ async function getGroupsVocabulary(userId, groupIds, onlyStaged) {
     where: {
       userId,
       ...(onlyStaged ? { '$Drawer.stage$': 0 } : null),
-      [Op.or]: [
-        groupIds.map((groupId) => {
-          return { groupId };
-        }),
-      ],
+      groupId: {
+        [Op.or]: [groupIds],
+      },
     },
   });
 

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -74,7 +74,7 @@ async function createTranslations(translations, userId, languagePackageId, vocab
   return false;
 }
 
-async function getGroupVocabulary(userId, groupId, search) {
+async function getGroupVocabulary(userId, groupId, search, onlyStaged) {
   const group = await Group.count({
     where: {
       id: groupId,
@@ -92,11 +92,19 @@ async function getGroupVocabulary(userId, groupId, search) {
         model: Translation,
         attributes: ['name'],
       },
+      {
+        model: Drawer,
+        attributes: ['stage'],
+      },
     ],
     attributes: ['id', 'name', 'active', 'description'],
     where: {
       [Op.and]: [
-        { userId, groupId },
+        {
+          userId,
+          groupId,
+          ...(onlyStaged ? { '$Drawer.stage$': 0 } : null),
+        },
         search && {
           [Op.or]: [
             sequelize.where(sequelize.fn('lower', sequelize.col('VocabularyCard.name')), {

--- a/app/Services/VocabularyServiceProvider.js
+++ b/app/Services/VocabularyServiceProvider.js
@@ -154,11 +154,7 @@ async function getGroupsVocabulary(userId, groupIds, onlyStaged, onlyActivated) 
     where: {
       userId,
       ...(onlyStaged ? { '$Drawer.stage$': 0 } : null),
-      ...(onlyActivated
-        ? sequelize.where('$Drawer.stage$', {
-            [Op.gt]: 0,
-          })
-        : null),
+      ...(onlyActivated ? { '$Drawer.stage$': !0 } : null),
       groupId: {
         [Op.or]: [groupIds],
       },

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -223,6 +223,9 @@
           },
           {
             "$ref": "#/components/parameters/stats"
+          },
+          {
+            "$ref": "#/components/parameters/onlyActivated"
           }
         ],
         "responses": {
@@ -297,6 +300,12 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/languagePackageId"
+          },
+          {
+            "$ref": "#/components/parameters/onlyActivated"
+          },
+          {
+            "$ref": "#/components/parameters/onlyStaged"
           }
         ],
         "responses": {
@@ -361,6 +370,9 @@
           },
           {
             "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/onlyStaged"
           }
         ],
         "responses": {
@@ -392,7 +404,13 @@
             "$ref": "#/components/parameters/limit"
           },
           {
-            "$ref": "#/components/parameters/staged"
+            "$ref": "#/components/parameters/onlyStaged"
+          },
+          {
+            "$ref": "#/components/parameters/onlyActivated"
+          },
+          {
+            "$ref": "#/components/parameters/query/groupId"
           }
         ],
         "responses": {
@@ -1254,15 +1272,34 @@
           "default": false
         }
       },
-      "staged": {
+      "onlyActivated": {
         "in": "query",
-        "name": "staged",
-        "description": "If true, all unactivated vocabs will be returned",
+        "name": "onlyActivated",
+        "description": "Only return packages/groups/vocabs if it has at least one activated vocab card",
         "schema": {
           "type": "boolean",
           "default": false
         }
       },
+      "onlyStaged": {
+        "in": "query",
+        "name": "onlyStaged",
+        "description": "Only return packages/groups/vocabs if it hast at least one unactivated vocab card",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "query": {
+        "groupId": {
+        "in": "query",
+        "name": "groupId",
+        "description": "if this parameters will be added to the query, it will return all vocabs from this specific group. Can be combined with only activated and onlyStaged. you can add multiple groupIds with: ?groupId={groupId1}&groupId={groupId2}",
+        "schema": {
+          "type": "string"
+        }
+      }
+      },      
       "answer": {
         "in": "query",
         "name": "answer",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If there is no changelog entry, label this PR as trivial to bypass the Danger warning -->

|               Status                |                Type                 | Env Vars Change |
| :---------------------------------: | :---------------------------------: | :-------------: |
| :heavy_check_mark:  Ready | Feature |     No      |

## Description

This PR will be the basis for the upcoming PR in the Frontend (issued here vocascan/vocascan-frontend#132).
I updated the routes to return groups and vocabs that contain staged vocabs.

1. Updated GET group route
GET `/api/languagePackage/:languagePackageId/group`
Added query parameter `?onlyStaged=true` to only return groups that contain at least one unactivated/staged vocab
Added query parameter `?onlyActivated=true` to only return groups that contain at least one active vocab

2. Updated GET language package route
GET `/api/languagePackage/`
Added query parameter `?onlyActivated=true` to only return language packages that contain at least one group with at least one active vocab

3. Update GET query route
GET `/languagePackage/:languagePackageId/query`
Add query parameter `?groupId={groupId}&groupId={groupId}` to return only vocabs from these group
Add query parameter `onlyStaged=true` to return only vocabs that are staged
Add query parameter `onlyActivated=true` to return only vocabs that are already activated
(`groupId` query parameter can be combined with either `onlyStaged` or `onlyActivated`)

4. Updated GET vocab group
GET `/api/group/:groupId/vocabulary`
Added query parameter `?onlyStaged=true` to only return vocabs of a group that are already activated (for custom learning)




<!--- Describe your changes in detail -->

## Motivation and Context

The activate function was kind of useless, as you could just start a query that throws every inactivated/staged vocabs in a query. You couldn't decide which group you want to add to your daily query. With this PR i want to provide the backend basis to implement group specific vocab activation.

In addition to this this PR will give the basis to implement the upcoming "Custom Learning" functionality (issued here vocascan/vocascan-frontend#126

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots / GIFs (if appropriate):

<!--- Bonus points for GIFS --->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] I have considered the accessibility of my changes (i.e. did I add proper content descriptions to images, or run my changes with talkback enabled?)
- [x] I have documented my code if needed

## Resolves
vocascan/vocascan-server#93
vocascan/vocascan-frontend#126
vocascan/vocascan-frontend#132

<!-- List the issues that will be closed by this PR in the following format -->
<!-- resolves AN-123 -->
<!-- This will ensure that they are automatically closed once the PR is merged -->
